### PR TITLE
Work around imagemagick svg rendering issue

### DIFF
--- a/SlideTester/App/BaseProcessor.cs
+++ b/SlideTester/App/BaseProcessor.cs
@@ -25,9 +25,9 @@ namespace SlideTester.App
 {
     internal static class ImageCompareThresholds
     {
-        public static double Error { get; } = 0.9;
-        public static double Warning { get; } = 0.95;
-        public static double Info { get; } = 0.99;
+        public static double Error { get; } = 0.1;
+        public static double Warning { get; } = 0.05;
+        public static double Info { get; } = 0.01;
     }
     
     internal abstract class BaseProcessor<T> : SafeDisposable, IVerbProcessor where T : BaseOptions
@@ -215,17 +215,17 @@ namespace SlideTester.App
             var imgDiff = new MagickImage();
             double diff = referenceImage.Compare(comparandImage, ErrorMetric.RootMeanSquared, imgDiff);
             //await imgDiff.WriteAsync(outputDiffImagePath).ConfigureAwait(false);
-            if (diff <= ImageCompareThresholds.Error)
+            if (diff >= ImageCompareThresholds.Error)
             {
                 logMessage.AppendLine(
                     $"[ERROR] Images differ too much ({diff}): {referenceImagePath} vs. {comparandImagePath}");
             }
-            else if (diff > ImageCompareThresholds.Error && diff <= ImageCompareThresholds.Warning)
+            else if (diff < ImageCompareThresholds.Error && diff >= ImageCompareThresholds.Warning)
             {
                 logMessage.AppendLine(
                     $"[WARNING] Images differ too much ({diff}): {referenceImagePath} vs. {comparandImagePath}");
             }
-            else if (diff > ImageCompareThresholds.Warning && diff <= ImageCompareThresholds.Info)
+            else if (diff < ImageCompareThresholds.Warning && diff >= ImageCompareThresholds.Info)
             {
                 logMessage.AppendLine(
                     $"[INFO] Images differ tool much ({diff}): {referenceImagePath} vs. {comparandImagePath}");

--- a/SlideTester/SlideTester.sln.DotSettings
+++ b/SlideTester/SlideTester.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=comparand/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Panopto/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
1. Change to use different aspose image export method to export as bitmap
2. Convert to using png files everywhere instead of jpg for better image comparison. Note: ImageMagick saves png as lossless by default.
3. I also changed the ppt logic to export a bitmap (uncompressed) and then used ImageMagick to convert to png.